### PR TITLE
Implement ping command for the Websocket and customize URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+target
+*.iml

--- a/src/main/java/com/binance/client/SubscriptionOptions.java
+++ b/src/main/java/com/binance/client/SubscriptionOptions.java
@@ -1,5 +1,6 @@
 package com.binance.client;
 
+import com.binance.client.constant.BinanceApiConstants;
 import com.binance.client.exception.BinanceApiException;
 import java.net.URI;
 
@@ -8,16 +9,18 @@ import java.net.URI;
  */
 public class SubscriptionOptions {
 
-    private String uri = "wss://api.binance.pro/";
+    private String uri = BinanceApiConstants.WS_API_BASE_URL;
     private boolean isAutoReconnect = true;
     private int receiveLimitMs = 300_000;
     private int connectionDelayOnFailure = 15;
+    private int pingInterval = 60_000;
 
     public SubscriptionOptions(SubscriptionOptions options) {
         this.uri = options.uri;
         this.isAutoReconnect = options.isAutoReconnect;
         this.receiveLimitMs = options.receiveLimitMs;
         this.connectionDelayOnFailure = options.connectionDelayOnFailure;
+        this.pingInterval = options.pingInterval;
     }
 
     public SubscriptionOptions() {
@@ -58,6 +61,15 @@ public class SubscriptionOptions {
     }
 
     /**
+     * Specify the delay between each Ping request to keep stream alive.
+     *
+     * @param pingInterval The delay time in milliseconds.
+     */
+    public void setPingInterval(int pingInterval) {
+        this.pingInterval = pingInterval;
+    }
+
+    /**
      * When the connection lost is happening on the subscription line, specify
      * whether the client reconnect to server automatically.
      * <p>
@@ -92,4 +104,6 @@ public class SubscriptionOptions {
     public String getUri() {
         return uri;
     }
+
+    public int getPingInterval() { return this.pingInterval; }
 }

--- a/src/main/java/com/binance/client/impl/WebSocketConnection.java
+++ b/src/main/java/com/binance/client/impl/WebSocketConnection.java
@@ -1,5 +1,6 @@
 package com.binance.client.impl;
 
+import com.binance.client.SubscriptionOptions;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
@@ -34,17 +35,18 @@ public class WebSocketConnection extends WebSocketListener {
     private final int connectionId;
     private final boolean autoClose;
 
-    private String subscriptionUrl = BinanceApiConstants.WS_API_BASE_URL;
+    private String subscriptionUrl;
 
-    WebSocketConnection(WebsocketRequest request,
+    WebSocketConnection(WebsocketRequest request, SubscriptionOptions options,
             WebSocketWatchDog watchDog) {
-        this(request, watchDog, false);
+        this(request, options, watchDog, false);
     }
 
-    WebSocketConnection(WebsocketRequest request, WebSocketWatchDog watchDog, boolean autoClose) {
+    WebSocketConnection(WebsocketRequest request, SubscriptionOptions options, WebSocketWatchDog watchDog, boolean autoClose) {
         this.connectionId = WebSocketConnection.connectionCounter++;
         this.request = request;
         this.autoClose = autoClose;
+        this.subscriptionUrl = options.getUri();
 
         this.okhttpRequest = request.authHandler == null ? new Request.Builder().url(subscriptionUrl).build()
                 : new Request.Builder().url(subscriptionUrl).build();
@@ -97,6 +99,10 @@ public class WebSocketConnection extends WebSocketListener {
             log.error("[Sub][" + this.connectionId + "] Failed to send message");
             closeOnError();
         }
+    }
+
+    void ping() {
+        send("ping");
     }
 
     @Override

--- a/src/main/java/com/binance/client/impl/WebSocketStreamClientImpl.java
+++ b/src/main/java/com/binance/client/impl/WebSocketStreamClientImpl.java
@@ -39,7 +39,7 @@ public class WebSocketStreamClientImpl implements SubscriptionClient {
         if (watchDog == null) {
             watchDog = new WebSocketWatchDog(options);
         }
-        WebSocketConnection connection = new WebSocketConnection(request, watchDog, autoClose);
+        WebSocketConnection connection = new WebSocketConnection(request, this.options, watchDog, autoClose);
         if (autoClose == false) {
             connections.add(connection);
         }


### PR DESCRIPTION
* Implement an automatic `Ping` request for the Websocket connect (interval customizable via `SubscriptionOptions`, default to 60s).
* Customize WS URL to be able to pass a custom value via `SubscriptionOptions`. ex: use testnet URL